### PR TITLE
Adiciona gerenciamento mensal

### DIFF
--- a/frontend/src/components/Dashboard/MonthlyManagementCard.tsx
+++ b/frontend/src/components/Dashboard/MonthlyManagementCard.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo } from 'react';
+import { FixedExpense, MonthlyVariation, Transaction } from '../../types/FinanceTypes';
+import { getActualFixedItemAmount, isItemActiveInMonth } from '../../utils/financeUtils';
+
+type MonthlyManagementCardProps = {
+  date: Date;
+  monthlyIncome: number;
+  fixedExpenses: FixedExpense[];
+  monthlyVariations: MonthlyVariation[];
+  transactions: Transaction[]; // deve incluir parceladas
+  investmentMonthlyAmount: number; // configurado pelo usuário (UI/localStorage)
+};
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const getDaysInMonth = (date: Date) => {
+  // último dia do mês: dia 0 do mês seguinte
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+};
+
+export const MonthlyManagementCard: React.FC<MonthlyManagementCardProps> = ({
+  date,
+  monthlyIncome,
+  fixedExpenses,
+  monthlyVariations,
+  transactions,
+  investmentMonthlyAmount,
+}) => {
+  const {
+    committedTotal,
+    remainingAfterInvestment,
+    daysInMonth,
+    perDay,
+    perWeek,
+  } = useMemo(() => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+
+    const committedFixed = fixedExpenses
+      .filter((expense) => isItemActiveInMonth(expense, date))
+      .reduce(
+        (sum, expense) =>
+          sum +
+          getActualFixedItemAmount(
+            expense.id,
+            'expense',
+            year,
+            month,
+            expense.amount,
+            monthlyVariations,
+          ),
+        0,
+      );
+
+    const committedInstallmentsValue = transactions
+      .filter((t) => ('installmentInfo' in t && !!t.installmentInfo))
+      .filter((t) => {
+        const d = new Date(t.date);
+        return d.getFullYear() === year && d.getMonth() === month;
+      })
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    const committed = committedFixed + committedInstallmentsValue;
+
+  const remainingInvest = monthlyIncome - committed - investmentMonthlyAmount;
+
+    const dim = getDaysInMonth(date);
+    const safeRemaining = isFinite(remainingInvest) ? remainingInvest : 0;
+
+    return {
+      committedTotal: committed,
+      remainingAfterInvestment: remainingInvest,
+      daysInMonth: dim,
+      perDay: safeRemaining / dim,
+      perWeek: safeRemaining / (dim / 7),
+    };
+  }, [date, fixedExpenses, monthlyVariations, transactions, monthlyIncome, investmentMonthlyAmount]);
+
+  const negativeClass = (value: number) => (value < 0 ? 'text-red-600' : 'text-blue-600');
+
+  return (
+    <div className="space-y-3">
+
+      <div className="border-t border-gray-200 pt-3">
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-medium text-gray-600">Investimento</span>
+          <span className="text-sm font-semibold text-gray-800">- {formatBRL(investmentMonthlyAmount)}</span>
+        </div>
+        <div className="flex justify-between items-center mt-2">
+          <span className="text-sm font-medium text-gray-600">Gerenciamento</span>
+          <span className={`text-lg font-bold ${negativeClass(remainingAfterInvestment)}`}>{formatBRL(remainingAfterInvestment)}</span>
+        </div>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500">Por dia</p>
+            <p className={`text-sm font-semibold ${negativeClass(perDay)}`}>{formatBRL(perDay)}</p>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500">Por semana</p>
+            <p className={`text-sm font-semibold ${negativeClass(perWeek)}`}>{formatBRL(perWeek)}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Dashboard/SortableDashboardItem.tsx
+++ b/frontend/src/components/Dashboard/SortableDashboardItem.tsx
@@ -38,6 +38,13 @@ export const SortableDashboardItem: React.FC<SortableDashboardItemProps> = ({
     5: 'col-span-5', // Adicione quantos precisar
     6: 'col-span-6',
   };
+
+  // Para widgets pequenos (span=1), limitamos a altura do conteúdo pra não
+  // estourar a linha do grid; o componente interno pode usar scroll.
+  const contentHeightBySpan: Record<number, string> = {
+    1: 'h-80',
+  };
+
   const containerClasses = `
     bg-white shadow rounded-lg
     ${spanClasses[span] || 'col-span-1'}
@@ -49,6 +56,6 @@ export const SortableDashboardItem: React.FC<SortableDashboardItemProps> = ({
           <GripVerticalIcon className="w-5 h-5" />
         </button>
       </div>
-      <div className="p-6">{children}</div>
+      <div className={`p-6 ${contentHeightBySpan[span] || ''} overflow-hidden`}>{children}</div>
     </div>;
 };

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { UserIcon } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
-import { ThemeToggle } from './ThemeToggle.tsx'
+import { UserMenu } from './UserMenu';
 export const Header: React.FC = () => {
   const {
     currentUser
@@ -21,22 +20,7 @@ export const Header: React.FC = () => {
         </p>
       </div>
       <div className="flex items-center space-x-4">
-        <div className="p-2 text-gray-500 rounded-full hover:bg-gray-100">
-          <ThemeToggle/>
-        </div>
-        <div className="flex items-center space-x-2">
-          <div className="w-10 h-10 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center">
-            <UserIcon className="w-5 h-5" />
-          </div>
-          <div className="hidden md:block">
-            <p className="text-sm font-medium text-gray-700">
-              {currentUser?.name || 'Usuário'}
-            </p>
-            <p className="text-xs text-gray-500">
-              {currentUser?.email || 'usuario@exemplo.com'}
-            </p>
-          </div>
-        </div>
+        <UserMenu />
       </div>
     </header>;
 };

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { HomeIcon, TagIcon, DollarSignIcon, CoinsIcon, CreditCardIcon, ShoppingCartIcon, CalendarIcon, ClockIcon, LogOutIcon } from 'lucide-react';
-import { useAuth } from '../../context/AuthContext';
+import { HomeIcon, TagIcon, DollarSignIcon, CoinsIcon, CreditCardIcon, ShoppingCartIcon, CalendarIcon, ClockIcon } from 'lucide-react';
 export const Sidebar: React.FC = () => {
-  const {
-    logout
-  } = useAuth();
   return <aside className="w-64 h-full bg-white border-r border-gray-200 flex flex-col">
       <div className="p-4 border-b border-gray-200">
         <h1 className="text-xl font-bold text-blue-600">FinControl</h1>
@@ -109,11 +105,5 @@ export const Sidebar: React.FC = () => {
           </li>
         </ul>
       </nav>
-      <div className="p-4 border-t border-gray-200">
-        <button onClick={logout} className="flex items-center w-full px-4 py-2 text-gray-700 rounded-md hover:bg-gray-100">
-          <LogOutIcon className="w-5 h-5 mr-3" />
-          Sair
-        </button>
-      </div>
     </aside>;
 };

--- a/frontend/src/components/Layout/UserMenu.tsx
+++ b/frontend/src/components/Layout/UserMenu.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { ChevronDownIcon, LogOutIcon, PiggyBankIcon, UserIcon } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
+import { useTheme } from '../../context/ThemeContext';
+import { useInvestmentSettings } from '../../hooks/useInvestmentSettings';
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+export const UserMenu: React.FC = () => {
+  const { currentUser, logout } = useAuth();
+  const { theme, toggleTheme } = useTheme();
+  const { investmentMonthlyAmount, setInvestmentMonthlyAmount } = useInvestmentSettings();
+
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState<string>(() => String(investmentMonthlyAmount));
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setInputValue(String(investmentMonthlyAmount));
+  }, [investmentMonthlyAmount]);
+
+  useEffect(() => {
+    const onClickOutside = (e: MouseEvent) => {
+      if (!open) return;
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [open]);
+
+  const applyInvestment = () => {
+    setInvestmentMonthlyAmount(inputValue);
+  };
+
+  const handleInvestmentKeyDown = (e: any) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      applyInvestment();
+    }
+  };
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center space-x-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 px-2 py-2"
+      >
+        <div className="w-10 h-10 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center">
+          <UserIcon className="w-5 h-5" />
+        </div>
+        <div className="hidden md:block text-left">
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            {currentUser?.name || 'Usuário'}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {currentUser?.email || 'usuario@exemplo.com'}
+          </p>
+        </div>
+        <ChevronDownIcon className={`w-4 h-4 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-4 z-50">
+          <div className="space-y-3">
+            <div>
+              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">Configurações</p>
+            </div>
+
+            <div className="flex items-start space-x-3">
+              <div className="bg-gray-100 dark:bg-gray-700 p-2 rounded-full">
+                <PiggyBankIcon className="w-4 h-4 text-gray-600 dark:text-gray-200" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-100">Investimento mensal</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">Define quanto você quer separar todo mês.</p>
+                <div className="mt-2 flex items-center space-x-2">
+                  <input
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onBlur={applyInvestment}
+                    onKeyDown={handleInvestmentKeyDown}
+                    placeholder="0"
+                    className="w-full px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100"
+                  />
+                  <button
+                    type="button"
+                    onClick={applyInvestment}
+                    className="px-3 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700"
+                  >
+                    Salvar
+                  </button>
+                </div>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Atual: {formatBRL(investmentMonthlyAmount)}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
+              <div>
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-100">Tema</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">Atual: {theme === 'dark' ? 'Escuro' : 'Claro'}</p>
+              </div>
+              <button
+                type="button"
+                onClick={toggleTheme}
+                className="px-3 py-2 text-sm rounded-md bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600"
+              >
+                Alternar
+              </button>
+            </div>
+
+            <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  logout();
+                }}
+                className="w-full flex items-center justify-center space-x-2 px-3 py-2 text-sm rounded-md bg-red-50 text-red-700 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30"
+              >
+                <LogOutIcon className="w-4 h-4" />
+                <span>Sair</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useInvestmentSettings.ts
+++ b/frontend/src/hooks/useInvestmentSettings.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+const STORAGE_KEY_BASE = 'investmentMonthlyAmount';
+const INVESTMENT_EVENT = 'fincontrol:investmentMonthlyAmountChanged';
+
+const parseCurrencyLike = (value: string): number => {
+  // aceita "1234,56" ou "1234.56" ou "R$ 1.234,56"
+  const cleaned = value
+    .replace(/\s/g, '')
+    .replace(/R\$/gi, '')
+    .replace(/\./g, '')
+    .replace(',', '.');
+
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export const useInvestmentSettings = () => {
+  const { currentUser } = useAuth();
+
+  const storageKey = useMemo(() => {
+    const suffix = currentUser?.id ? `:${currentUser.id}` : '';
+    return `${STORAGE_KEY_BASE}${suffix}`;
+  }, [currentUser?.id]);
+
+  const [investmentMonthlyAmount, setInvestmentMonthlyAmount] = useState<number>(() => {
+    const raw = localStorage.getItem(storageKey);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) ? n : 0;
+  });
+
+  // Mantém reatividade quando:
+  // - outra instância do hook atualiza (mesma página)
+  // - o usuário muda (storageKey muda)
+  useEffect(() => {
+    const syncFromStorage = () => {
+      const raw = localStorage.getItem(storageKey);
+      const n = raw ? Number(raw) : 0;
+      setInvestmentMonthlyAmount(Number.isFinite(n) ? n : 0);
+    };
+
+    // 1) Sincroniza imediatamente quando storageKey muda
+    syncFromStorage();
+
+    // 2) Event listener (mesma aba)
+    const onCustom = (e: Event) => {
+      const detail = (e as CustomEvent<{ key: string }>).detail;
+      if (detail?.key === storageKey) {
+        syncFromStorage();
+      }
+    };
+
+    // 3) Storage event (entre abas/janelas)
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === storageKey) {
+        syncFromStorage();
+      }
+    };
+
+    window.addEventListener(INVESTMENT_EVENT, onCustom);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(INVESTMENT_EVENT, onCustom);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, [storageKey]);
+
+  const updateInvestmentMonthlyAmount = useCallback(
+    (value: number | string) => {
+      const next = typeof value === 'string' ? parseCurrencyLike(value) : value;
+      const safe = Number.isFinite(next) ? Math.max(0, next) : 0;
+      setInvestmentMonthlyAmount(safe);
+      localStorage.setItem(storageKey, String(safe));
+
+      // Dispara evento pra outras partes da UI reagirem sem refresh.
+      window.dispatchEvent(new CustomEvent(INVESTMENT_EVENT, { detail: { key: storageKey } }));
+    },
+    [storageKey],
+  );
+
+  return {
+    investmentMonthlyAmount,
+    setInvestmentMonthlyAmount: updateInvestmentMonthlyAmount,
+  };
+};


### PR DESCRIPTION
- Adiciona configuração de investimento mensal.
    - O valor do investimento é deduzido do saldo livre para calcular o orçamento disponível do mês.
 - A configuração de investimento mensal e a configuração de tema da página foram movidos para um menu Dropdown do usuário.
- Alteração nos Widgets da Dashboard para que mostrem apenas as compras de gerenciamento do mês. Gastos fixos e compras parceladas não aparecem
